### PR TITLE
代理ログイン処理の実装

### DIFF
--- a/app/controllers/teachers/reservations_controller.rb
+++ b/app/controllers/teachers/reservations_controller.rb
@@ -2,17 +2,6 @@ class Teachers::ReservationsController < ApplicationController
   before_action :authenticate_teacher!
 
   def index
-    @reservations = current_teacher_reservations
-  end
-
-  private
-
-  def current_teacher_reservations
-    if current_teacher.admin? && session[:teacher_agent].present?
-      teacher = Teacher.find(session[:teacher_agent])
-      teacher.reservations
-    else
-      current_teacher.reservations
-    end
+    @reservations = current_teacher.reservations
   end
 end

--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -2,6 +2,8 @@
 
 class Teachers::SessionsController < Devise::SessionsController
   before_action :configure_sign_in_params, only: [:create]
+  before_action :authenticate_teacher!, only: %i[masquerade_sign_in]
+  before_action :signed_in_admin, only: %i[masquerade_sign_in]
 
   def masquerade_sign_in
     teacher = Teacher.find(params[:id])
@@ -11,7 +13,7 @@ class Teachers::SessionsController < Devise::SessionsController
   end
 
 
-  def back_to_owner()
+  def back_to_owner
     raise 'Failed. Masquerade signed in id not found.' unless session[:admin_id].present?
     admin = Teacher.find(session[:admin_id])
     bypass_sign_in(admin)
@@ -23,5 +25,11 @@ class Teachers::SessionsController < Devise::SessionsController
 
   def configure_sign_in_params
    devise_parameter_sanitizer.permit(:sign_in, keys: [:name])
+  end
+
+  def signed_in_admin
+    unless current_teacher.admin?
+      redirect_to root_url, alert: 'この操作は管理者のみが実行できます'
+    end
   end
 end

--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -3,6 +3,22 @@
 class Teachers::SessionsController < Devise::SessionsController
   before_action :configure_sign_in_params, only: [:create]
 
+  def masquerade_sign_in
+    teacher = Teacher.find(params[:id])
+    session[:admin_id] = current_teacher.id
+    bypass_sign_in(teacher)
+    redirect_to root_url, notice: "#{teacher.name}として代理ログインしました"
+  end
+
+
+  def back_to_owner()
+    raise 'Failed. Masquerade signed in id not found.' unless session[:admin_id].present?
+    admin = Teacher.find(session[:admin_id])
+    bypass_sign_in(admin)
+    session[:admin_id] = nil
+    redirect_to root_url, notice: 'ログアウトしました'
+  end
+
   protected
 
   def configure_sign_in_params

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -38,13 +38,6 @@ class TeachersController < ApplicationController
     redirect_to teachers_url, notice: 'Teacher was successfully destroyed.'
   end
 
-  def sign_in
-    if current_teacher.admin?
-      session[:teacher_agent] = @teacher.id
-    end
-    redirect_to root_url
-  end
-
   private
 
   def set_teacher

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+
+  def masquerade_signed_in?
+    session[:admin_id].present?
+  end
+
 end

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -7,10 +7,9 @@
       = link_to '予約の確認', users_reservations_path, class: 'nav-item nav-link'
       = link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-item nav-link'
     - if teacher_signed_in?
+      -if masquerade_signed_in?
+        = link_to '管理者にもどる', back_to_owner_path, class: 'nav-item nav-link'
       - if current_teacher.admin?
-        -if session[:teacher_agent].present?
-          = "代理ログイン中（#{session[:teacher_agent]}）"
-          = link_to '予約の確認', teachers_reservations_path, class: 'nav-item nav-link'
         = "#{current_teacher.name} （管理者）"
         = link_to '講師の管理', teachers_path, class: 'nav-item nav-link'
       - else

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -3,6 +3,7 @@
   - if user_signed_in? || teacher_signed_in?
     - if user_signed_in?
       = "#{current_user.name} （生徒）"
+      = link_to 'レッスン一覧', users_lessons_path, class: 'nav-item nav-link'
       = link_to '予約の確認', users_reservations_path, class: 'nav-item nav-link'
       = link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-item nav-link'
     - if teacher_signed_in?

--- a/app/views/teachers/index.html.haml
+++ b/app/views/teachers/index.html.haml
@@ -12,7 +12,7 @@
     - @teachers.each do |teacher|
       %tr
         %td= link_to teacher.name, teacher
-        %td= link_to '代理ログイン', sign_in_teacher_path(teacher)
+        %td= link_to '代理ログイン', masquerade_teacher_path(teacher)
         %td= link_to '編集', edit_teacher_path(teacher)
         %td= link_to '削除', teacher, method: :delete, data: { confirm: '削除してよろしいですか？' }
 

--- a/app/views/teachers/lessons/new.html.haml
+++ b/app/views/teachers/lessons/new.html.haml
@@ -5,7 +5,7 @@
   = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
 
   .form-inputs
-    = f.input :language_id, as: :select, collection: Language.all, selected: @lesson.language.present? ? @lesson.language.id : Language.first.id
+    = f.input :language_id, as: :select, collection: Language.all, selected: Language.first.id
   .form-inputs
     = f.input :start_date, as: :datetime, discard_minute: true
   .form-inputs

--- a/app/views/users/lessons/index.html.haml
+++ b/app/views/users/lessons/index.html.haml
@@ -18,4 +18,3 @@
         %td
           = link_to '予約にすすむ', new_users_reservation_path({params: {lesson_id: lesson.id}})
 
-= link_to '戻る', users_reservations_path

--- a/app/views/users/reservations/index.html.haml
+++ b/app/views/users/reservations/index.html.haml
@@ -1,0 +1,4 @@
+%h1 予約したレッスン一覧
+
+= render 'reservations/reservation_list', reservations: @reservations
+

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,85 +1,16 @@
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On macOS with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem 'pg'
-#
+
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default
   database: online_language_lesson_development
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  #username: online_language_lesson
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: online_language_lesson_test
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password as a unix environment variable when you boot
-# the app. Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full rundown on how to provide these environment variables in a
-# production deployment.
-#
-# On Heroku and other platform providers, you may have a full connection URL
-# available as an environment variable. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# You can use this database configuration with:
-#
-#   production:
-#     url: <%= ENV['DATABASE_URL'] %>
-#
 production:
-  <<: *default
-  database: online_language_lesson_production
-  username: online_language_lesson
-  password: <%= ENV['ONLINE_LANGUAGE_LESSON_DATABASE_PASSWORD'] %>
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,6 @@ Rails.application.routes.draw do
       registrations: 'users/registrations'
   }
 
-
   namespace :users do
     resources :lessons, only: [:index]
     resources :reservations, only: %i[index new create]
@@ -27,9 +26,18 @@ Rails.application.routes.draw do
     resources :lessons
   end
 
-  resources :teachers do
-    member do
-      get :sign_in
+
+  devise_scope :teacher do
+    resources :teachers do
+      get "masquerade", to: "teachers/sessions#masquerade_sign_in", on: :member
     end
+    get "back_to_owner", to: "teachers/sessions#back_to_owner"
+  end
+
+  resources :teachers do
+  #   member do
+  #     get "masquerade", to: "teachers/sessions#masquerade_sign_in"
+  #     # get :sign_in
+  #   end
   end
 end


### PR DESCRIPTION
[oivoodoo/devise\_masquerade](https://github.com/oivoodoo/devise_masquerade)
のコードを読みながら、代理ログインに必要な処理だけを追ってみて、実装をしてみました。

1. 講師IDに対してのログイン、ログアウトのアクションを追加（`devise_scope`で定義したrouteです。）
2. ログインが実行されたら、管理者IDをsessionに保存してログインする（`bypass_sign_in`でwardenコールバックをスキップする）
3. ログアウトはsessionから管理者IDを取り出してログイン（sessionの管理者IDはこのタイミングで削除する）