### PR TITLE
チケットに有効期限を設ける

### DIFF
--- a/app/controllers/users/reservations_controller.rb
+++ b/app/controllers/users/reservations_controller.rb
@@ -48,7 +48,12 @@ class Users::ReservationsController < ApplicationController
   def pay_coupon
     if current_user.done_trial?
       raise BadRequest, 'チケット残高がありません' if current_user.coupon_balance_empty?
-      current_user.coupon_balances.create(number: -1)
+      if current_user.subscription_balance > 0
+        expire_at = current_user.subscription_expire_at
+        current_user.coupon_balances.create(number: -1, period: true, expire_at: expire_at)
+      else
+        current_user.coupon_balances.create(number: -1)
+      end
     end
   end
 end

--- a/app/controllers/users/subscriptions_controller.rb
+++ b/app/controllers/users/subscriptions_controller.rb
@@ -6,13 +6,13 @@ class Users::SubscriptionsController < ApplicationController
   end
 
   def create
-    coupon = Plan.find(params[:plan_id])
+    plan = Plan.find(params[:plan_id])
 
     customer = params[:use_registerd_id].present? ?
                    current_user.customer :
                    current_user.attach_customer(params[:stripeToken])
 
-    if current_user.charge(customer, coupon)
+    if current_user.subscribe(customer, plan)
       redirect_to users_reservations_url, notice: 'チケットを購入しました'
     else
       redirect_to new_users_charge_path

--- a/app/controllers/users/subscriptions_controller.rb
+++ b/app/controllers/users/subscriptions_controller.rb
@@ -18,4 +18,52 @@ class Users::SubscriptionsController < ApplicationController
       redirect_to new_users_charge_path
     end
   end
+
+  def edit
+    @user = current_user
+  end
+
+  def update
+    case params[:subscription][:update_type]
+    when "plan"
+      update_plan
+    when "suspend"
+      update_suspend
+    when "card"
+      update_card
+    end
+  end
+
+  private
+
+  def update_plan
+    if current_user.subscription.update(subscription_params)
+      redirect_to user_url(current_user), notice: 'プランを更新しました'
+    else
+      @user = current_user
+      render :edit
+    end
+  end
+
+  def update_suspend
+    if current_user.subscription.update(subscription_params)
+      redirect_to user_url(current_user), notice: "プランを#{current_user.subscription.suspend_status}に変更しました"
+    else
+      @user = current_user
+      render :edit
+    end
+  end
+
+  def update_card
+    if current_user.update_stripe_token(params[:stripeToken])
+      redirect_to user_url(current_user), notice: 'カードを更新しました'
+    else
+      @user = current_user
+      render :edit
+    end
+  end
+
+  def subscription_params
+    params.require(:subscription).permit(:plan_id, :suspend)
+  end
 end

--- a/app/controllers/users/subscriptions_controller.rb
+++ b/app/controllers/users/subscriptions_controller.rb
@@ -1,0 +1,21 @@
+class Users::SubscriptionsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @user = current_user
+  end
+
+  def create
+    coupon = Plan.find(params[:plan_id])
+
+    customer = params[:use_registerd_id].present? ?
+                   current_user.customer :
+                   current_user.attach_customer(params[:stripeToken])
+
+    if current_user.charge(customer, coupon)
+      redirect_to users_reservations_url, notice: 'チケットを購入しました'
+    else
+      redirect_to new_users_charge_path
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,5 +3,6 @@ class UsersController < ApplicationController
 
   def show
     @lesson_feedbacks = current_user.lesson_feedbacks
+    @subscription = Subscription.find_by(user: current_user)
   end
 end

--- a/app/models/billing.rb
+++ b/app/models/billing.rb
@@ -1,0 +1,3 @@
+class Billing < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/billing.rb
+++ b/app/models/billing.rb
@@ -1,3 +1,7 @@
 class Billing < ApplicationRecord
   belongs_to :user
+
+  def plan
+    Plan.find(plan_id)
+  end
 end

--- a/app/models/coupon_balance.rb
+++ b/app/models/coupon_balance.rb
@@ -1,7 +1,12 @@
 class CouponBalance < ApplicationRecord
   belongs_to :user
-
   scope :available, -> {
     where("expire_at > ?", Date.current)
+  }
+  scope :subscriptions, -> {
+    where(period: true).available
+  }
+  scope :infinite, -> {
+    where(period: false)
   }
 end

--- a/app/models/coupon_balance.rb
+++ b/app/models/coupon_balance.rb
@@ -1,3 +1,7 @@
 class CouponBalance < ApplicationRecord
   belongs_to :user
+
+  scope :available, -> {
+    where("expire_at > ?", Date.current)
+  }
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,7 +1,7 @@
 class Plan < ActiveHash::Base
   self.data=[
-      {id: 1, name: "ライトプラン：毎月5回、月額7000円", price: 7000, number: 5},
-      {id: 2, name: "スタンダードプラン：毎月7回、月額9500円", price: 9500, number: 7},
-      {id: 3, name: "ヘビープラン：毎月10回、月額12000円", price: 12000, number: 10},
+      {id: 1, name: "ライトプラン：毎月5回", price: 7000, number: 5},
+      {id: 2, name: "スタンダードプラン：毎月7回", price: 9500, number: 7},
+      {id: 3, name: "ヘビープラン：毎月10回", price: 12000, number: 10},
   ]
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,0 +1,7 @@
+class Plan < ActiveHash::Base
+  self.data=[
+      {id: 1, name: "ライトプラン：毎月5回、月額7000円", price: 7000, number: 5},
+      {id: 2, name: "スタンダードプラン：毎月7回、月額9500円", price: 9500, number: 7},
+      {id: 3, name: "ヘビープラン：毎月10回、月額12000円", price: 12000, number: 10},
+  ]
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,15 @@
+class Subscription < ApplicationRecord
+  belongs_to :user
+
+  def next_billing_date
+    start_at.since(1.month)
+  end
+
+  def plan_name
+    Plan.find(plan_id).name
+  end
+
+  def suspend_status
+    suspend? ? "休止中" : "自動継続中"
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -5,8 +5,8 @@ class Subscription < ApplicationRecord
     start_at.since(1.month)
   end
 
-  def plan_name
-    Plan.find(plan_id).name
+  def plan
+    Plan.find(plan_id)
   end
 
   def suspend_status

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,13 @@ class User < ApplicationRecord
     customer
   end
 
+  def update_stripe_token(stripe_token)
+    return false if self.customer.blank?
+
+    Stripe::Customer.update(self.customer.id, source: stripe_token)
+    true
+  end
+
   def charge(customer, coupon)
     Stripe::Charge.create(
         :customer => customer.id,
@@ -85,6 +92,6 @@ class User < ApplicationRecord
 
   def subscription_expire_at
     return nil if subscription_balance == 0
-    coupon_balances.available.first.expire_at
+    coupon_balances.available.last.expire_at
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ApplicationRecord
         :description => "Onlineレッスン定期チケット #{plan.name}",
         :currency => "jpy"
     )
-    self.plan_balances.create(number: plan.number, expire_at: 30.days.since)
+    self.coupon_balances.create(number: plan.number, expire_at: 30.days.since, period: true)
     true
   rescue Stripe::CardError => e
     flash[:error] = e.message
@@ -63,4 +63,16 @@ class User < ApplicationRecord
     coupon_balances.available.sum(:number)
   end
 
+  def subscription_balance
+    coupon_balances.subscriptions.sum(:number)
+  end
+
+  def infinite_balance
+    coupon_balances.infinite.sum(:number)
+  end
+
+  def subscription_expire_at
+    return nil if subscription_balance == 0
+    coupon_balances.available.first.expire_at
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,10 @@ class User < ApplicationRecord
   has_many :lesson_feedbacks, dependent: :destroy
   has_many :reports, dependent: :destroy
   has_many :lessons, through: :reservations
+  has_many :billings, dependent: :destroy
 
   has_one :subscription, dependent: :destroy
+
   def has_customer_id?
     stripe_customer_id.present?
   end
@@ -51,6 +53,8 @@ class User < ApplicationRecord
     )
     self.coupon_balances.create(number: plan.number, expire_at: 30.days.since, period: true)
     Subscription.create(user: self, plan_id: plan.id, start_at: Date.current)
+    self.billings.create(plan_id: plan.id)
+
     true
   rescue Stripe::CardError => e
     flash[:error] = e.message

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,12 +41,26 @@ class User < ApplicationRecord
     false
   end
 
+  def subscribe(customer, plan)
+    Stripe::Charge.create(
+        :customer => customer.id,
+        :amount => plan.price,
+        :description => "Onlineレッスン定期チケット #{plan.name}",
+        :currency => "jpy"
+    )
+    self.plan_balances.create(number: plan.number, expire_at: 30.days.since)
+    true
+  rescue Stripe::CardError => e
+    flash[:error] = e.message
+    false
+  end
+
   def coupon_balance_empty?
     calc_coupon_balance == 0
   end
 
   def calc_coupon_balance
-    coupon_balances.sum(:number)
+    coupon_balances.available.sum(:number)
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,13 @@ class User < ApplicationRecord
         :currency => "jpy"
     )
     self.coupon_balances.create(number: plan.number, expire_at: 30.days.since, period: true)
-    Subscription.create(user: self, plan_id: plan.id, start_at: Date.current)
+
+    if user.subscription
+      user.subscription.update(plan_id: plan.id, start_at: Date.current)
+    else
+      Subscription.create(user: self, plan_id: plan.id, start_at: Date.current)
+    end
+
     self.billings.create(plan_id: plan.id)
 
     true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   has_many :reports, dependent: :destroy
   has_many :lessons, through: :reservations
 
+  has_one :subscription, dependent: :destroy
   def has_customer_id?
     stripe_customer_id.present?
   end
@@ -49,6 +50,7 @@ class User < ApplicationRecord
         :currency => "jpy"
     )
     self.coupon_balances.create(number: plan.number, expire_at: 30.days.since, period: true)
+    Subscription.create(user: self, plan_id: plan.id, start_at: Date.current)
     true
   rescue Stripe::CardError => e
     flash[:error] = e.message

--- a/app/views/users/_billings.html.haml
+++ b/app/views/users/_billings.html.haml
@@ -1,0 +1,12 @@
+%h3 決済履歴
+%table.table.table-striped.billings
+  %thead
+    %th プラン
+    %th 請求金額
+    %th 決済日
+  %tbody
+    - user.billings.each do |bill|
+      %tr
+        %td= bill.plan.name
+        %td= "#{bill.plan.price} 円"
+        %td= l(bill.created_at, format: :short_jp)

--- a/app/views/users/_coupon_balance.html.haml
+++ b/app/views/users/_coupon_balance.html.haml
@@ -1,0 +1,11 @@
+%h3 チケット残高
+.coupon_balance
+  - if user.subscription_balance > 0
+    期限ありチケット:
+    = "#{user.subscription_balance}回"
+    有効期限
+    = l(user.subscription_expire_at, format: :short_jp)
+    まで
+  -if user.infinite_balance > 0
+    無期限チケット:
+    = "#{user.infinite_balance}回"

--- a/app/views/users/_coupon_balance.html.haml
+++ b/app/views/users/_coupon_balance.html.haml
@@ -1,11 +1,18 @@
 %h3 チケット残高
-.coupon_balance
-  - if user.subscription_balance > 0
-    期限ありチケット:
-    = "#{user.subscription_balance}回"
-    有効期限
-    = l(user.subscription_expire_at, format: :short_jp)
-    まで
-  -if user.infinite_balance > 0
-    無期限チケット:
-    = "#{user.infinite_balance}回"
+%table.table.table-striped.coupon_balance
+  %thead
+    %th チケット種別
+    %th 残りチケット数
+  %tbody
+    %tr
+      %td 期限ありチケット
+      %td
+        = "#{user.subscription_balance}回"
+        -if user.subscription_expire_at
+          %br
+          有効期限
+          = l(user.subscription_expire_at, format: :short_jp)
+          まで
+    %tr
+      %td 無期限チケット
+      %td= "#{user.infinite_balance}回"

--- a/app/views/users/_lesson_feedback.html.haml
+++ b/app/views/users/_lesson_feedback.html.haml
@@ -1,0 +1,13 @@
+%h3 レッスンフィードバック
+
+%table.table.table-striped.lesson_feedback
+  %thead
+    %tr
+      %th レッスン概要
+      %th フィードバックの内容
+
+  %tbody
+    - lesson_feedbacks.includes(:lesson).each do |feedback|
+      %tr
+        %td= feedback.lesson.summary
+        %td= feedback.content

--- a/app/views/users/_subscriptions.html.haml
+++ b/app/views/users/_subscriptions.html.haml
@@ -1,6 +1,6 @@
 %h3 定期決済プランの情報
 
-- if @subscription
+- if subscription
   %table.table.table-striped.subscriptions
     %thead
       %tr
@@ -10,9 +10,9 @@
         %th 休止状態
     %tbody
       %tr
-        %td= @subscription.plan.name
-        %td #{@subscription.plan.price}円
-        %td= l(@subscription.next_billing_date, format: :short_jp)
+        %td= subscription.plan.name
+        %td #{subscription.plan.price}円
+        %td= l(subscription.next_billing_date, format: :short_jp)
         %td
-          = @subscription.suspend_status
-          -# = user_subscription
+          = subscription.suspend_status
+  = link_to 'プラン変更', edit_users_subscription_path(subscription)

--- a/app/views/users/_subscriptions.html.haml
+++ b/app/views/users/_subscriptions.html.haml
@@ -1,0 +1,18 @@
+%h3 定期決済プランの情報
+
+- if @subscription
+  %table.table.table-striped.subscriptions
+    %thead
+      %tr
+        %th 契約プラン
+        %th 月額料金
+        %th 次回決済日
+        %th 休止状態
+    %tbody
+      %tr
+        %td= @subscription.plan.name
+        %td #{@subscription.plan.price}円
+        %td= l(@subscription.next_billing_date, format: :short_jp)
+        %td
+          = @subscription.suspend_status
+          -# = user_subscription

--- a/app/views/users/reservations/_form.html.haml
+++ b/app/views/users/reservations/_form.html.haml
@@ -49,6 +49,11 @@
       %p
         = "初回無料でレッスンを受講できます！"
       = f.button :submit, "予約する", class: 'btn btn-primary'
-  = link_to '定期チケット購入', new_users_subscription_path
-  でお得に受講できます
+
+  - if current_user.subscription
+    = "現在、#{current_user.subscription.plan_name}を#{current_user.subscription.suspend_status}です。"
+    = "次回のチケット購入日は#{l(current_user.subscription.next_billing_date, format: :short_jp)}です。"
+  - else
+    = link_to '定期チケット購入', new_users_subscription_path
+    でお得に受講できます
 

--- a/app/views/users/reservations/_form.html.haml
+++ b/app/views/users/reservations/_form.html.haml
@@ -32,18 +32,8 @@
           = link_to 'チケットを購入', new_users_charge_path
           してください。
       - else
-        %p
-          - if current_user.subscription_balance > 0
-            %p
-              期限ありチケット:
-              = "#{current_user.subscription_balance}回"
-              有効期限
-              = l(current_user.subscription_expire_at, format: :short_jp)
-              まで
-            %p
-              無期限チケット:
-              = "#{current_user.infinite_balance}回"
-          = "チケットを1消費します。（#{current_user.calc_coupon_balance}→#{current_user.calc_coupon_balance-1}）"
+        =render 'users/coupon_balance', user: current_user
+        = "チケットを1消費します。（#{current_user.calc_coupon_balance}→#{current_user.calc_coupon_balance-1}）"
         = f.button :submit, "予約する", class: 'btn btn-primary'
     - else
       %p
@@ -51,8 +41,15 @@
       = f.button :submit, "予約する", class: 'btn btn-primary'
 
   - if current_user.subscription
-    = "現在、#{current_user.subscription.plan_name}を#{current_user.subscription.suspend_status}です。"
-    = "次回のチケット購入日は#{l(current_user.subscription.next_billing_date, format: :short_jp)}です。"
+    現在、
+    %u= current_user.subscription.plan_name
+    を
+    %u= current_user.subscription.suspend_status
+    です。
+    %br
+    次回のチケット購入日は
+    %u=l(current_user.subscription.next_billing_date, format: :short_jp)
+    です。
   - else
     = link_to '定期チケット購入', new_users_subscription_path
     でお得に受講できます

--- a/app/views/users/reservations/_form.html.haml
+++ b/app/views/users/reservations/_form.html.haml
@@ -42,7 +42,7 @@
 
   - if current_user.subscription
     現在、
-    %u= current_user.subscription.plan_name
+    %u= current_user.subscription.plan.name
     を
     %u= current_user.subscription.suspend_status
     です。

--- a/app/views/users/reservations/_form.html.haml
+++ b/app/views/users/reservations/_form.html.haml
@@ -39,3 +39,6 @@
       %p
         = "初回無料でレッスンを受講できます！"
       = f.button :submit, "予約する", class: 'btn btn-primary'
+  = link_to '定期チケット購入', new_users_subscription_path
+  でお得に受講できます
+

--- a/app/views/users/reservations/_form.html.haml
+++ b/app/views/users/reservations/_form.html.haml
@@ -33,6 +33,16 @@
           してください。
       - else
         %p
+          - if current_user.subscription_balance > 0
+            %p
+              期限ありチケット:
+              = "#{current_user.subscription_balance}回"
+              有効期限
+              = l(current_user.subscription_expire_at, format: :short_jp)
+              まで
+            %p
+              無期限チケット:
+              = "#{current_user.infinite_balance}回"
           = "チケットを1消費します。（#{current_user.calc_coupon_balance}→#{current_user.calc_coupon_balance-1}）"
         = f.button :submit, "予約する", class: 'btn btn-primary'
     - else

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -18,6 +18,7 @@
           -# = user_subscription
 
 = render 'users/coupon_balance', user: current_user
+= render 'users/billings', user: current_user
 
 %table.table.table-striped.lesson_feedback
   %thead

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,6 +1,22 @@
 %h1 ユーザーページ
 
-%table.table.table-striped.teachers
+%h3 定期決済プランの情報
+
+- if @subscription
+  %table.table.table-striped.subscriptions
+    %thead
+      %tr
+        %th 契約プラン
+        %th 次回決済日
+        %th 休止状態
+    %tbody
+      %tr
+        %td= @subscription.plan_name
+        %td= l(@subscription.next_billing_date, format: :short_jp)
+        %td= @subscription.suspend_status
+
+
+%table.table.table-striped.lesson_feedback
   %thead
     %tr
       %th レッスン概要

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,6 +1,6 @@
 %h1 ユーザーページ
 
-= render 'users/subscriptions', user: current_user
+= render 'users/subscriptions', subscription: @subscription
 = render 'users/coupon_balance', user: current_user
 = render 'users/billings', user: current_user
 = render 'users/lesson_feedback', lesson_feedbacks: @lesson_feedbacks

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -13,8 +13,11 @@
       %tr
         %td= @subscription.plan_name
         %td= l(@subscription.next_billing_date, format: :short_jp)
-        %td= @subscription.suspend_status
+        %td
+          = @subscription.suspend_status
+          -# = user_subscription
 
+= render 'users/coupon_balance', user: current_user
 
 %table.table.table-striped.lesson_feedback
   %thead

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,33 +1,6 @@
 %h1 ユーザーページ
 
-%h3 定期決済プランの情報
-
-- if @subscription
-  %table.table.table-striped.subscriptions
-    %thead
-      %tr
-        %th 契約プラン
-        %th 次回決済日
-        %th 休止状態
-    %tbody
-      %tr
-        %td= @subscription.plan_name
-        %td= l(@subscription.next_billing_date, format: :short_jp)
-        %td
-          = @subscription.suspend_status
-          -# = user_subscription
-
+= render 'users/subscriptions', user: current_user
 = render 'users/coupon_balance', user: current_user
 = render 'users/billings', user: current_user
-
-%table.table.table-striped.lesson_feedback
-  %thead
-    %tr
-      %th レッスン概要
-      %th フィードバックの内容
-
-  %tbody
-    - @lesson_feedbacks.includes(:lesson).each do |feedback|
-      %tr
-        %td= feedback.lesson.summary
-        %td= feedback.content
+= render 'users/lesson_feedback', lesson_feedbacks: @lesson_feedbacks

--- a/app/views/users/subscriptions/edit.html.haml
+++ b/app/views/users/subscriptions/edit.html.haml
@@ -1,0 +1,90 @@
+%script{ src: "https://js.stripe.com/v3/" }
+
+%h1 定期決済の変更
+
+%h3 プランの変更
+- if @user.has_customer_id?
+  = form_with model: @user.subscription, url: users_subscription_path, local: true do |f|
+    .form-row
+      = f.hidden_field :update_type, value: "plan"
+      .form-inputs
+        = f.select :plan_id, Plan.all.map { |plan| [plan.name, plan.id] }, {}, {class: 'form-control'}
+    = f.submit 'プランを変更する', class: 'btn btn-success'
+
+%h3 定期決済の休止・再開
+= form_with model: @user.subscription, url: users_subscription_path, local: true do |f|
+  .form-row
+    .form-inputs
+      = f.hidden_field :update_type, value: "suspend"
+      = f.hidden_field :suspend, value: !@user.subscription.suspend
+  - if @user.subscription.suspend
+    = f.submit '定期決済を再開する', class: 'btn btn-success'
+  - else
+    = f.submit '定期決済を休止する', class: 'btn btn-danger'
+
+%h3 クレジットカードの変更
+
+= form_with model: @user.subscription, url: users_subscription_path, id: "payment-form" do |f|
+  .form-row
+    %label{ for:"card-element" }
+      クレジット・デビットカード番号
+    #card-element.mt-1{ style: 'width: 500px' }
+    #card-errors{ role: "alert" }
+    .form-inputs
+      = f.hidden_field :update_type, value: "card"
+  %button.mt-1{class:"btn btn-success"} お支払い
+
+:javascript
+  var stripe = Stripe('#{Rails.configuration.stripe[:publishable_key]}');
+  var elements = stripe.elements();
+  var style = {
+    base: {
+      color: '#32325d',
+      fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
+      fontSmoothing: 'antialiased',
+      fontSize: '16px',
+      '::placeholder': {
+        color: '#aab7c4'
+      }
+    },
+    invalid: {
+      color: '#fa755a',
+      iconColor: '#fa755a'
+    }
+  };
+  var card = elements.create('card', {style: style, hidePostalCode: true});
+  card.mount('#card-element');
+
+  card.addEventListener('change', function(event) {
+    var displayError = document.getElementById('card-errors');
+    if (event.error) {
+      displayError.textContent = event.error.message;
+    } else {
+      displayError.textContent = '';
+    }
+  });
+
+  var form = document.getElementById('payment-form');
+  form.addEventListener('submit', function(event) {
+    event.preventDefault();
+
+    stripe.createToken(card).then(function(result) {
+      if (result.error) {
+        var errorElement = document.getElementById('card-errors');
+        errorElement.textContent = result.error.message;
+      } else {
+        stripeTokenHandler(result.token);
+      }
+    });
+  });
+
+  function stripeTokenHandler(token) {
+    var form = document.getElementById('payment-form');
+    var hiddenInput = document.createElement('input');
+    hiddenInput.setAttribute('type', 'hidden');
+    hiddenInput.setAttribute('name', 'stripeToken');
+    hiddenInput.setAttribute('value', token.id);
+    form.appendChild(hiddenInput);
+
+    form.submit();
+  }

--- a/app/views/users/subscriptions/new.html.haml
+++ b/app/views/users/subscriptions/new.html.haml
@@ -1,0 +1,76 @@
+%script{ src: "https://js.stripe.com/v3/" }
+
+- if @user.has_customer_id?
+  = form_with url: users_subscriptions_path, local: true do |f|
+    .form-row
+      以前と同じカードで支払う場合はこちらから。
+      = f.hidden_field :use_registerd_id, value: 1
+      .form-inputs
+        = f.select :plan_id, Plan.all.map { |plan| [plan.name, plan.id] }, {}, {class: 'form-control'}
+    = f.submit '登録済みのカードで支払う', class: 'btn btn-success'
+
+
+= form_with url: users_subscriptions_path, id: "payment-form" do |f|
+  .form-row
+    %label{ for:"card-element" }
+      クレジット・デビットカード番号
+    #card-element.mt-1{ style: 'width: 500px' }
+    #card-errors{ role: "alert" }
+    .form-inputs
+      = f.select :plan_id, Plan.all.map { |plan| [plan.name, plan.id] }, {}, {class: 'form-control'}
+  %button.mt-1{class:"btn btn-success"} お支払い
+
+:javascript
+  var stripe = Stripe('#{Rails.configuration.stripe[:publishable_key]}');
+  var elements = stripe.elements();
+  var style = {
+    base: {
+      color: '#32325d',
+      fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
+      fontSmoothing: 'antialiased',
+      fontSize: '16px',
+      '::placeholder': {
+        color: '#aab7c4'
+      }
+    },
+    invalid: {
+      color: '#fa755a',
+      iconColor: '#fa755a'
+    }
+  };
+  var card = elements.create('card', {style: style, hidePostalCode: true});
+  card.mount('#card-element');
+
+  card.addEventListener('change', function(event) {
+    var displayError = document.getElementById('card-errors');
+    if (event.error) {
+      displayError.textContent = event.error.message;
+    } else {
+      displayError.textContent = '';
+    }
+  });
+
+  var form = document.getElementById('payment-form');
+  form.addEventListener('submit', function(event) {
+    event.preventDefault();
+
+    stripe.createToken(card).then(function(result) {
+      if (result.error) {
+        var errorElement = document.getElementById('card-errors');
+        errorElement.textContent = result.error.message;
+      } else {
+        stripeTokenHandler(result.token);
+      }
+    });
+  });
+
+  function stripeTokenHandler(token) {
+    var form = document.getElementById('payment-form');
+    var hiddenInput = document.createElement('input');
+    hiddenInput.setAttribute('type', 'hidden');
+    hiddenInput.setAttribute('name', 'stripeToken');
+    hiddenInput.setAttribute('value', token.id);
+    form.appendChild(hiddenInput);
+
+    form.submit();
+  }

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,3 +26,6 @@ ja:
   date:
     formats:
       short_date: "%Y-%m-%d"
+  datetime:
+    formats:
+      short_jp: "%Y年%m月%d日"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
     resources :lessons, only: [:index]
     resources :reservations, only: %i[index new create]
     resources :charges, only: %i[new create]
-    resources :subscriptions, only: %i[new create]
+    resources :subscriptions, only: %i[new create edit update]
   end
 
   namespace :teachers do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     resources :lessons, only: [:index]
     resources :reservations, only: %i[index new create]
     resources :charges, only: %i[new create]
+    resources :subscriptions, only: %i[new create]
   end
 
   namespace :teachers do

--- a/db/migrate/20200421124919_add_expire_at_to_coupon_balances.rb
+++ b/db/migrate/20200421124919_add_expire_at_to_coupon_balances.rb
@@ -1,0 +1,5 @@
+class AddExpireAtToCouponBalances < ActiveRecord::Migration[6.0]
+  def change
+    add_column :coupon_balances, :expire_at, :datetime, null: false, default: 20.years.since
+  end
+end

--- a/db/migrate/20200421131140_add_coupon_type_to_coupon_balances.rb
+++ b/db/migrate/20200421131140_add_coupon_type_to_coupon_balances.rb
@@ -1,0 +1,5 @@
+class AddCouponTypeToCouponBalances < ActiveRecord::Migration[6.0]
+  def change
+    add_column :coupon_balances, :period, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20200424225952_create_subscriptions.rb
+++ b/db/migrate/20200424225952_create_subscriptions.rb
@@ -1,0 +1,12 @@
+class CreateSubscriptions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :subscriptions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :plan_id, null: false
+      t.boolean :suspend, null:false, default:false
+      t.datetime :start_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200425004353_create_billings.rb
+++ b/db/migrate/20200425004353_create_billings.rb
@@ -1,0 +1,10 @@
+class CreateBillings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :billings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :plan_id, null:false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_27_045308) do
+ActiveRecord::Schema.define(version: 2020_04_21_124919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2020_03_27_045308) do
     t.integer "number", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "expire_at", default: "2040-04-21 12:51:35", null: false
     t.index ["user_id"], name: "index_coupon_balances_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_21_131140) do
+ActiveRecord::Schema.define(version: 2020_04_24_225952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,16 @@ ActiveRecord::Schema.define(version: 2020_04_21_131140) do
     t.index ["user_id"], name: "index_reservations_on_user_id"
   end
 
+  create_table "subscriptions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "plan_id", null: false
+    t.boolean "suspend", default: false, null: false
+    t.datetime "start_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_subscriptions_on_user_id"
+  end
+
   create_table "teachers", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "email", default: "", null: false
@@ -117,4 +127,5 @@ ActiveRecord::Schema.define(version: 2020_04_21_131140) do
   add_foreign_key "reports", "users"
   add_foreign_key "reservations", "lessons"
   add_foreign_key "reservations", "users"
+  add_foreign_key "subscriptions", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_21_124919) do
+ActiveRecord::Schema.define(version: 2020_04_21_131140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_04_21_124919) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "expire_at", default: "2040-04-21 12:51:35", null: false
+    t.boolean "period", default: false, null: false
     t.index ["user_id"], name: "index_coupon_balances_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_24_225952) do
+ActiveRecord::Schema.define(version: 2020_04_25_004353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "billings", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "plan_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_billings_on_user_id"
+  end
 
   create_table "coupon_balances", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -117,6 +125,7 @@ ActiveRecord::Schema.define(version: 2020_04_24_225952) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "billings", "users"
   add_foreign_key "coupon_balances", "users"
   add_foreign_key "languages", "teachers"
   add_foreign_key "lesson_feedbacks", "lessons"

--- a/spec/factories/billings.rb
+++ b/spec/factories/billings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :billing do
+    user { nil }
+    plan_id { 1 }
+  end
+end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :subscription do
+    user { nil }
+    plan { nil }
+    suspend { false }
+    start_at { "2020-04-25 07:59:52" }
+  end
+end

--- a/spec/models/billing_spec.rb
+++ b/spec/models/billing_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Billing, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Subscription, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
買い切りのチケットに、定期決済プラン（30日間有効）のチケットが追加されたので、チケットに対して有効期限をもたせるようにした。

`coupon_balances`テーブルのフィールドに、`expire_at:datetime`（期限）と、`period:boolean`（期限付きかどうか）を追加してみました。